### PR TITLE
Revive link

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,4 +2,4 @@
  
  
 
-Helper methods for accessing openbis (http://www.cisd.ethz.ch/software/openBIS)
+Helper methods for accessing openbis (https://labnotebook.ch/)


### PR DESCRIPTION
See diff ;-) They didn't set up / maintain a [redirect](https://en.wikipedia.org/wiki/URL_redirect) for some reason.

Please consider checking your other ReadMe files for the same issue.