### PR TITLE
Hotfix 1.5.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Release Version Changelog
 
+## 1.5.2
+* Bump `org.apache.logging:log4j:log4j-api` `2.15.0` -> `2.17.0`
+* Bump `org.apache.logging:log4j:log4j-core` `2.15.0` -> `2.17.0`
+* Fixes CVE-2021-45105
+
 ## 1.5.1
 * Bump `org.apache.logging:log4j:log4j-api` `2.13.2` -> `2.15.0`
 * Bump `org.apache.logging:log4j:log4j-core` `2.13.2` -> `2.15.0`

--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
 	<!-- we only need to tell maven where to find our parent pom and other QBiC 
 		dependencies -->
 	<properties>
-		<log4j.version>2.15.0</log4j.version>
+		<log4j.version>2.17.0</log4j.version>
 	</properties>
 	<repositories>
 		<repository>


### PR DESCRIPTION
## 1.5.2
* Bump `org.apache.logging:log4j:log4j-api` `2.15.0` -> `2.17.0`
* Bump `org.apache.logging:log4j:log4j-core` `2.15.0` -> `2.17.0`
* Fixes CVE-2021-45105