### PR TITLE
Hotfix 1.5.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@
 * Bump `org.apache.logging:log4j:log4j-core` `2.17.0` -> `2.17.1`
 * Fixes CVE-2021-44832
 
+## 1.5.2
+* Bump `org.apache.logging:log4j:log4j-api` `2.15.0` -> `2.17.0`
+* Bump `org.apache.logging:log4j:log4j-core` `2.15.0` -> `2.17.0`
+* Fixes CVE-2021-45105
+
 ## 1.5.1
 * Bump `org.apache.logging:log4j:log4j-api` `2.13.2` -> `2.15.0`
 * Bump `org.apache.logging:log4j:log4j-core` `2.13.2` -> `2.15.0`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,9 @@
 # Release Version Changelog
 
-## 1.5.2
-* Bump `org.apache.logging:log4j:log4j-api` `2.15.0` -> `2.17.0`
-* Bump `org.apache.logging:log4j:log4j-core` `2.15.0` -> `2.17.0`
-* Fixes CVE-2021-45105
+## 1.5.3
+* Bump `org.apache.logging:log4j:log4j-api` `2.17.0` -> `2.17.1`
+* Bump `org.apache.logging:log4j:log4j-core` `2.17.0` -> `2.17.1`
+* Fixes CVE-2021-44832
 
 ## 1.5.1
 * Bump `org.apache.logging:log4j:log4j-api` `2.13.2` -> `2.15.0`

--- a/pom.xml
+++ b/pom.xml
@@ -10,12 +10,12 @@
 	</parent>
 	<artifactId>openbis-client-lib</artifactId>
 	<packaging>jar</packaging>
-	<version>1.5.1</version>
+	<version>1.5.3</version>
 	<name>openBIS client library</name>
 	<!-- we only need to tell maven where to find our parent pom and other QBiC 
 		dependencies -->
 	<properties>
-		<log4j.version>2.17.0</log4j.version>
+		<log4j.version>2.17.1</log4j.version>
 	</properties>
 	<repositories>
 		<repository>


### PR DESCRIPTION
## 1.5.3
* Bump `org.apache.logging:log4j:log4j-api` `2.17.0` -> `2.17.1`
* Bump `org.apache.logging:log4j:log4j-core` `2.17.0` -> `2.17.1`
* Fixes CVE-2021-44832
